### PR TITLE
Temporary use deliver_now for debitors notifications

### DIFF
--- a/app/services/notifications_service.rb
+++ b/app/services/notifications_service.rb
@@ -11,7 +11,7 @@ class NotificationsService
 
   def notify_debitors
     debitors.each do |debitor|
-      NotificationsMailer.with(user: debitor).notify_about_debt.deliver_later
+      NotificationsMailer.with(user: debitor).notify_about_debt.deliver_now
     end
   end
 end


### PR DESCRIPTION
deliver_later не работает с адаптером отложенных задач :async при вызове
доставки уведомлений из задачи cron (так как процесс сразу же
завершается).

Временно используем deliver_now, до внедрения полноценного асинхронного
обработчика отложенных задач.