### PR TITLE
bepaid notifications: Don't send notification about unsuccessfull transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'cancancan', '~> 2.0'
 gem 'devise'
 gem 'devise-i18n'
-gem 'bootstrap-sass', '>= 3.1.1'
+gem 'bootstrap-sass', '>= 3.4.1'
 gem 'haml'
 gem 'haml-rails'
 gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,13 +44,13 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
     arel (8.0.0)
-    autoprefixer-rails (7.2.5)
+    autoprefixer-rails (9.4.9)
       execjs
     bcrypt (3.1.11)
     bindex (0.5.0)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     brakeman (4.2.1)
     builder (3.2.3)
     bundler-audit (0.6.0)
@@ -254,6 +254,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     sexp_processor (4.10.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -307,7 +310,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
-  bootstrap-sass (>= 3.1.1)
+  bootstrap-sass (>= 3.4.1)
   brakeman
   bundler-audit
   byebug

--- a/app/controllers/admin/erip_transactions_controller.rb
+++ b/app/controllers/admin/erip_transactions_controller.rb
@@ -136,7 +136,9 @@ class Admin::EripTransactionsController < AdminController
     respond_to do |format|
       if @erip_transaction.save
         format.json { render :show, status: :created, location: admin_erip_transaction_url(@erip_transaction) }
-        NotificationsMailer.with(transaction: @erip_transaction).notify_about_payment.deliver_later unless @erip_transaction.user.nil?
+        unless @erip_transaction.user.nil? or @erip_transaction.status != "successful"
+          NotificationsMailer.with(transaction: @erip_transaction).notify_about_payment.deliver_later 
+        end
       else
         format.json { render json: @erip_transaction.errors, status: :unprocessable_entity }
       end


### PR DESCRIPTION
If notification about unsuccessfull transaction has been received, don't
send "Thanks for payment" mail to user.