### PR TITLE
Fix broken bepaid notifications handling

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -44,6 +44,8 @@ class Ability
 
     # for bepaid notifications
     can [:create, :bepaid_notify], EripTransaction
+    # double previous line until fully understanding how cancancan works
+    can [:create, :bepaid_notify], :erip_transaction
 
     if user.present?
       can :chart, :main

--- a/spec/controllers/admin/erip_transactions_controller_spec.rb
+++ b/spec/controllers/admin/erip_transactions_controller_spec.rb
@@ -291,6 +291,13 @@ RSpec.describe Admin::EripTransactionsController, type: :controller do
   end
 
   describe "POST #bepaid_notify" do
+
+    it "can be done by guest" do
+      ability = Ability.new(nil)
+      r = ability.can?(:bepaid_notify, :erip_transaction)
+      expect(r).to be true
+    end
+
     it "rejects duplicated notification from bePaid" do
       EripTransaction.destroy_all
       Payment.destroy_all


### PR DESCRIPTION
After introducing cancancan ability management, bepaid notifications
handling is broken:

I, [2019-03-04T10:44:05.050546 #8112]  INFO -- : Started POST "/admin/erip_transactions/bepaid_notify" for 54.246.193.48 at 2019-03-04 1
0:44:05 +0300
I, [2019-03-04T10:44:05.053151 #8112]  INFO -- : Processing by Admin::EripTransactionsController#bepaid_notify as */*
I, [2019-03-04T10:44:05.053486 #8112]  INFO -- :   Parameters: <hidden>
E, [2019-03-04T10:44:06.604516 #8112] ERROR -- : Cannot bepaid_notify on erip_transaction
I, [2019-03-04T10:44:06.605150 #8112]  INFO -- : Redirected to https://hackerspace.by/users/sign_in

Add test for this ability and add abilities for :erip_transaction, not
for EripTransaction (to be clarified in future).