### PR TITLE
reduce warnings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have LF line endings on checkout.
+bin/* text eol=lf

--- a/app/views/layouts/_gplus_meta_tags.html.haml
+++ b/app/views/layouts/_gplus_meta_tags.html.haml
@@ -1,5 +1,5 @@
 %meta{itemprop: "name", content: page_title }
 %meta{itemprop: "description", content: page_description }
-%meta{itemprop: "image", content: image_url('og.png') }
+%meta{itemprop: "image", content: image_url('/images/og.png') }
 %meta{itemprop: "author", content: "https://plus.google.com/communities/110277676123000449866" }
 %meta{itemprop: "publisher", content: "https://plus.google.com/communities/110277676123000449866" }

--- a/app/views/layouts/_icons.html.haml
+++ b/app/views/layouts/_icons.html.haml
@@ -10,5 +10,5 @@
 %link{rel: "icon", type: "image/png", sizes: "16x16", href: "/favicon-16x16.png" }
 %link{rel: "manifest", href: "/site.webmanifest" }
 %link{rel: "mask-icon", href: "/safari-pinned-tab.svg", color: "#009966" }
-%link{rel: "image_src", href: image_url('og.png') }
+%link{rel: "image_src", href: image_url('/images/og.png') }
 %link{rel: "canonical", href: "https://hackerspace.by/" }

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -7,7 +7,7 @@
         %span.icon-bar
         %span.icon-bar
       %a.navbar-brand#brand{href: root_path}
-        = image_tag 'logo_site.svg', height: '70px', class: "hsopen-#{@hs_open_status}", title: t("hsopen.#{@hs_open_status}").to_s
+        = image_tag '/images/logo_site.svg', height: '70px', class: "hsopen-#{@hs_open_status}", title: t("hsopen.#{@hs_open_status}").to_s
     .collapse.navbar-collapse#navbar
       %ul.nav.navbar-nav.lead
         %li

--- a/app/views/layouts/_og_meta_tags.html.haml
+++ b/app/views/layouts/_og_meta_tags.html.haml
@@ -3,8 +3,8 @@
 %meta{property: "og:url", content: "https://hackerspace.by/" }
 %meta{property: "og:site_name", content: "hackerspace.by" }
 %meta{property: "og:description", content: page_description }
-%meta{property: "og:image", content: image_url('og.png') }
-%meta{property: "og:image:secure_url", content: image_url('og.png') }
+%meta{property: "og:image", content: image_url('/images/og.png') }
+%meta{property: "og:image:secure_url", content: image_url('/images/og.png') }
 %meta{property: "og:image:type", content: "image/png"}
 %meta{property: "og:image:height", content: "600" }
 %meta{property: "og:image:width", content: "600" }

--- a/app/views/layouts/_vk_meta_tags.html.haml
+++ b/app/views/layouts/_vk_meta_tags.html.haml
@@ -1,4 +1,4 @@
 %meta{property: "vk:title", content: page_title }
 %meta{property: "vk:url", content: "https://hackerspace.by/" }
 %meta{property: "vk:description", content: page_description }
-%meta{property: "vk:image", content: image_url('og.png') }
+%meta{property: "vk:image", content: image_url('/images/og.png') }

--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -34,15 +34,15 @@
       %p.lead
         =t('index.what_is_it_content').html_safe
     .col-md-4
-      = image_tag image_path('tele-robot.jpeg'), class: 'featurette-image img-responsive'
+      = image_tag image_path('/images/tele-robot.jpeg'), class: 'featurette-image img-responsive'
     .col-md-4
-      = image_tag image_path('tolik_mask.jpg'), class: 'featurette-image img-responsive'
+      = image_tag image_path('/images/tolik_mask.jpg'), class: 'featurette-image img-responsive'
   %hr.featurette-divider
     .row.featurette
       .col-md-4
-        =image_tag image_path('34983380_397380480743459_8393848152158896128_n.jpg'), class: 'featurette-image img-responsive'
+        =image_tag image_path('/images/34983380_397380480743459_8393848152158896128_n.jpg'), class: 'featurette-image img-responsive'
       .col-md-4
-        =image_tag image_path('39991017_586240851794144_334697966055055332_n.jpg'), class: 'featurette-image img-responsive'
+        =image_tag image_path('/images/39991017_586240851794144_334697966055055332_n.jpg'), class: 'featurette-image img-responsive'
       .col-md-4
         %h2.featurette-heading
           = t 'index.what_we_do'
@@ -63,11 +63,11 @@
           %p.lead
             = t('index.how_to_join_content').html_safe
         .col-md-7
-          =image_tag image_path('18121107_802382353254131_1686034606898319436_o-small.jpg'), class: 'featurette-image img-responsive'
+          =image_tag image_path('/images/18121107_802382353254131_1686034606898319436_o-small.jpg'), class: 'featurette-image img-responsive'
       %hr.featurette-divider
         .row.featurette
           .col-md-5
-            =image_tag image_path('19986028_1914939925414624_7965107293853319168_n.jpg'), class: 'featurette-image img-responsive'
+            =image_tag image_path('/images/19986028_1914939925414624_7965107293853319168_n.jpg'), class: 'featurette-image img-responsive'
           .col-md-7
             %h2.featurette-heading
               = t 'index.what_we_have'
@@ -87,5 +87,5 @@
               %p.lead
                 ="И не забудьте почитать #{link_to('правила', rules_path)}.".html_safe
             .col-md-7
-              =image_tag image_path('10295174_308861299272908_5853105603752271032_o-square.jpg'), class: 'featurette-image img-responsive'
+              =image_tag image_path('/images/10295174_308861299272908_5853105603752271032_o-square.jpg'), class: 'featurette-image img-responsive'
 %hr

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  
+  # stop "cannot render console" messages when in docker container
+  config.web_console.whiny_requests = false
 
   Paperclip.options[:command_path] = '/usr/local/bin/'
 end


### PR DESCRIPTION
Here I address some warnings which overwhelm the docker console:
- Shebang line ending ending with \r (github windows client pulling bin scripts with CRLF by default)
- Asset not found in asset pipeline (inconcise image paths)
- Cannot render console (dev machine ip address defaults to 127.0.0.0)