### PR TITLE
Fix Travis deploy. `rvm` needs to be explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
 - bundle exec brakeman -z
 deploy:
 - provider: script
-  script: .cicd/travis_deploy.sh
+  script: rvm use $TRAVIS_RUBY_VERSION do .cicd/travis_deploy.sh
   on:
     branch: master


### PR DESCRIPTION
https://docs.travis-ci.com/user/deployment-v2/providers/script/#ruby-version

The rest of the story 197868a169504a17bda64d588df787d7ea6ebc6e