### PR TITLE
bePaid notifications: Check authorization

### DIFF
--- a/app/controllers/admin/erip_transactions_controller.rb
+++ b/app/controllers/admin/erip_transactions_controller.rb
@@ -6,6 +6,10 @@ class Admin::EripTransactionsController < AdminController
 
   skip_before_action :verify_authenticity_token, only: :bepaid_notify
 
+  http_basic_authenticate_with name: Setting['bePaid_ID'],
+                               password: Setting['bePaid_secret'],
+                               only: :bepaid_notify
+
   # GET /erip_transactions
   # GET /erip_transactions.json
   def index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,6 +222,9 @@ class User < ApplicationRecord
 
   #TODO: maybe place this to concerns?
   def create_bepaid_bill
+    # Don't touch real web services during of test database initialization
+    return if Rails.env.test?
+
     user = self
 
     bp = BePaid::BePaid.new Setting['bePaid_baseURL'], Setting['bePaid_ID'], Setting['bePaid_secret']

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,8 @@ unless Rails.env.production?
 
   [Mac, Role, NfcKey, Project, Device, Event, News, Setting, User, EripTransaction, Payment].each { |model| model.destroy_all }
 
-  Setting.create(key: 'bePaid_ID', value: '', description: 'ID магазина из личного кабинета bePaid')
-  Setting.create(key: 'bePaid_secret', value: '', description: 'Секретный ключ из личного кабинета bePaid')
+  Setting.create(key: 'bePaid_ID', value: 'bepaidID', description: 'ID магазина из личного кабинета bePaid')
+  Setting.create(key: 'bePaid_secret', value: 'bepaidSecret', description: 'Секретный ключ из личного кабинета bePaid')
   Setting.create(key: 'bePaid_baseURL', value: 'https://api.bepaid.by', description: 'Базовый адрес для запросов к API bePaid')
   Setting.create(key: 'bePaid_serviceNo', value: '248', description: 'Номер услуги в bePaid для членских взносов')
   Setting.create(key: 'bib_baseURL', value: 'https://ibank.belinvestbank.by/', description: 'Bank API base URL')


### PR DESCRIPTION
Check credentials when handling bePaid notifications to prevent
injection of fake data.
Closes #174