### PR TITLE
Use `mina` without the rest of Gemfile dependencies

### DIFF
--- a/.cicd/travis_deploy.sh
+++ b/.cicd/travis_deploy.sh
@@ -21,6 +21,6 @@ ssh -i "$KEYPATH" mhs@hackerspace.by pwd
 
 echo "[x] Preparing and running 'mina' (Ruby deploy tool)"
 
-bundle install
-bundle exec mina deploy
+gem install mina
+mina deploy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ script:
 - bundle exec brakeman -z
 deploy:
 - provider: script
-  script: rvm use $TRAVIS_RUBY_VERSION do .cicd/travis_deploy.sh
+  script: .cicd/travis_deploy.sh
   on:
     branch: master

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'comma'
 gem 'will_paginate', '~> 3.1.0'
 gem 'chartkick'
 gem 'groupdate'
-gem 'mina', '~> 1.2'
 
 gem 'font-awesome-rails'
 
@@ -66,6 +65,8 @@ group :development do
   gem 'thin', platform: :ruby
   gem 'annotate'
   gem 'letter_opener'
+  # Ruby deployment tool (like Ansible, but in Ruby)
+  gem 'mina', '~> 1.2'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       thor (~> 0.18)
     byebug (11.1.3)
     cancancan (3.1.0)
-    chartkick (3.3.1)
+    chartkick (3.4.0)
     chronic (0.10.2)
     climate_control (0.2.0)
     cocaine (0.5.8)


### PR DESCRIPTION
This should speed up deployment (#450). Because `mina` just generates a `bash` script for deployment, it doesn't need any project specific imports.