### PR TITLE
Use GitLab CI (coz its Open Source)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+image: ruby:2.7
+
+build-job:
+  stage: build
+  cache: 
+    paths:
+      - vendor/ruby
+  before_script:
+    - ruby --version
+    - bundle install -j $(nproc) --path vendor/ruby
+  script:
+    - cp config/database.example.yml config/database.yml
+    - bundle exec rake db:setup RAILS_ENV=test
+    - bundle exec rails spec
+    - bundle exec bundle-audit check --update
+    - bundle exec brakeman -z
+
+deploy-job:
+  stage: deploy
+  script: .cicd/travis_deploy.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+


### PR DESCRIPTION
Closes #508 #509.

GitLab CI не требует кредитки, опенсурсен, т.е. можно и у себя развернуть если что. Если интеграция сработает, то статус будет виден на https://gitlab.com/abitrolly/hackerspace.by/-/pipelines

Использует PAT (Personal Access Tolen) с правами `public_repo`, чего должно хватать для публичного рапозитория. Почти по инструкции https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html#using-gitlab-cicd-with-a-github-repository