### PR TITLE
Revert rogue change slipped without reviews in #511

### DIFF
--- a/app/views/hackers/index.html.haml
+++ b/app/views/hackers/index.html.haml
@@ -15,8 +15,8 @@
   .row
     .col-lg-12
       = render 'hackers', hackers: @active_users
-  - if current_user.admin?
-    %h2 Suspended, banned and forgotten
-    .row 
-      .col-lg-12
-        = render 'hackers', hackers: @non_active_users
+
+  %h2 Suspended, banned and forgotten
+  .row
+    .col-lg-12
+      = render 'hackers', hackers: @non_active_users


### PR DESCRIPTION
It is not related to "versions bumped accordint to security warnings"

This partially reverts commit 6578f66c5b431159dac3ced1f48296ebce2f5f75.