### PR TITLE
WireGuard configs

### DIFF
--- a/app/controllers/hackers_controller.rb
+++ b/app/controllers/hackers_controller.rb
@@ -89,6 +89,7 @@ class HackersController < ApplicationController
 
   def edit
     @new_public_ssh_key = PublicSshKey.new(user: @user)
+    @new_wg_config = WgConfig.new(user: @user)
     redirect_to root_path, alert: 'Ошибка' unless (@user == current_user) || current_user.admin?
   end
 

--- a/app/controllers/wg_configs_controller.rb
+++ b/app/controllers/wg_configs_controller.rb
@@ -8,6 +8,10 @@ class WgConfigsController < ApplicationController
     @wgconfig = @user.wg_configs.new(wg_config_params)
 
     if @wgconfig.save
+      return send_data @wgconfig.to_s,
+        filename: "wg-hackerspace-#{@wgconfig.name}.conf",
+        type: "text/plain" if @wgconfig.privatekey.present?
+
       redirect_to edit_user_path(@user, anchor: 'wg-configs'), notice: "Конфигурация WireGuard создана успешно"
     else
       redirect_to edit_user_path(@user),
@@ -25,7 +29,7 @@ class WgConfigsController < ApplicationController
     wg = @user.wg_configs.find_by(id: params[:id])
 
     if wg
-      send_data wg.to_s, filename: "wg-hackerspace-#{wg.name}.conf", type: "text/plain"
+      redirect_to user_path(@user), alert: "Приватный ключ WireGuard не хранится на сервере. Создайте новую конфигурацию, чтобы скачать клиентский файл."
     else
       redirect_to user_path(@user), alert: "Конфигурация WireGuard не найдена"
     end
@@ -50,7 +54,8 @@ class WgConfigsController < ApplicationController
 
   def wg_config_params
     params.require(:wg_config).permit(
-      :name
+      :name,
+      :publickey
     )
   end
 

--- a/app/controllers/wg_configs_controller.rb
+++ b/app/controllers/wg_configs_controller.rb
@@ -1,0 +1,60 @@
+class WgConfigsController < ApplicationController
+  load_and_authorize_resource
+
+  before_action :set_user, only: [:create, :destroy, :export]
+  before_action :authenticate_token!, only: [:export_peers]
+
+  def create
+    @wgconfig = @user.wg_configs.new(wg_config_params)
+
+    if @wgconfig.save
+      redirect_to edit_user_path(@user, anchor: 'wg-configs'), notice: "Конфигурация WireGuard создана успешно"
+    else
+      redirect_to edit_user_path(@user),
+        alert: "Ошибка создания конфигурации WireGuard: #{@wgconfig.errors.full_messages.join("\n")}"
+    end
+  end
+
+  def destroy
+    wg = @user.wg_configs.find_by(id: params[:id])
+    wg&.destroy
+    redirect_to edit_user_path(@user, anchor: 'wg-configs')
+  end
+
+  def export
+    wg = @user.wg_configs.find_by(id: params[:id])
+
+    if wg
+      send_data wg.to_s, filename: "wg-hackerspace-#{wg.name}.conf", type: "text/plain"
+    else
+      redirect_to user_path(@user), alert: "Конфигурация WireGuard не найдена"
+    end
+  end
+
+  def export_peers
+    wgs = WgConfig.order(:user_id).select { |wg| wg.user.active? }
+
+    peers_config = wgs.map { |wg| wg.as_peer }.join("\n\n")
+
+    render plain: peers_config
+  end
+
+  private
+
+  def authenticate_token!
+    token = request.headers['Authorization']&.split&.last
+    if not ActiveSupport::SecurityUtils.secure_compare(token || '', Rails.application.secrets.wireguard_token) then
+      render plain: "Authorization required\n", status: :unauthorized
+    end
+  end
+
+  def wg_config_params
+    params.require(:wg_config).permit(
+      :name
+    )
+  end
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -54,6 +54,8 @@ class Ability
 
     can %i[ssh_keys detected_at_hackerspace find_by_mac useful], User
 
+    can [:export_peers], WgConfig
+
     if user.present?
       can :chart, :main
       can :image, :uploader
@@ -62,6 +64,7 @@ class Ability
       can :manage, Mac, user_id: user.id
       can :manage, NfcKey, user_id: user.id
       can :manage, PublicSshKey, user_id: user.id
+      can :manage, WgConfig, user_id: user.id
 
       can :read, Device
       can :add, Event

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,7 @@ class User < ApplicationRecord
   has_many :payments
   has_many :nfc_keys
   has_many :public_ssh_keys
+  has_many :wg_configs
   belongs_to :tariff
   belongs_to :guarantor1, class_name: 'User', optional: true
   belongs_to :guarantor2, class_name: 'User', optional: true

--- a/app/models/wg_config.rb
+++ b/app/models/wg_config.rb
@@ -2,6 +2,7 @@ require 'ipaddr'
 require 'open3'
 
 class WgConfig < ApplicationRecord
+  attr_reader :privatekey
 
   DEFAULT_SETTINGS = {
     'wgServerEndpoint' => {
@@ -33,11 +34,10 @@ class WgConfig < ApplicationRecord
   belongs_to :user
 
   validates :name, presence: true
-  validates :privatekey, presence: true
   validates :publickey, presence: true
   validates :name, uniqueness: { scope: :user_id }
 
-  before_validation :generate_keys!, on: :create, if: -> { privatekey.blank? }
+  before_validation :generate_keys!, on: :create, if: -> { publickey.blank? }
 
   def self.ensure_default_settings!
     DEFAULT_SETTINGS.each do |key, attributes|
@@ -49,8 +49,7 @@ class WgConfig < ApplicationRecord
   end
 
   def generate_keys!
-    self.privatekey = gen_privatekey
-    self.publickey = gen_publickey(self.privatekey)
+    @privatekey, self.publickey = gen_keypair
   end
 
   def addresses(as_networks=true)
@@ -68,11 +67,13 @@ class WgConfig < ApplicationRecord
     "#{ip}/#{IPAddr.new(Setting['wgNetmask']).to_i.to_s(2).count('1')}"
   end
 
-  def to_s
+  def to_s(private_key = privatekey)
+    raise "WireGuard private key is not stored; generate a new client configuration" if private_key.blank?
+
     lines = []
     lines << "# WireGuard config #{name}"
     lines << '[Interface]'
-    lines << "PrivateKey = #{privatekey}"
+    lines << "PrivateKey = #{private_key}"
     lines << "Address = #{self.addresses}"
     lines << ''
     lines << '[Peer]'
@@ -95,22 +96,13 @@ class WgConfig < ApplicationRecord
 
   private
 
-  def gen_privatekey
-    key, status = Open3.capture2("wg", "genkey")
-    raise "Failed to generate WireGuard private key" unless status.success?
+  def gen_keypair
+    output, status = Open3.capture2(Rails.root.join('bin/wg-keypair').to_s)
+    raise "Failed to generate WireGuard key pair" unless status.success?
 
-    key.strip
-  end
+    private_key, public_key = output.lines.map(&:strip)
+    raise "Failed to generate WireGuard key pair" if private_key.blank? || public_key.blank?
 
-  def gen_publickey(private_key)
-    stdout_str = ''
-    Open3.popen2("wg", "pubkey") do |stdin, stdout, wait_thr|
-      stdin.print(private_key)
-      stdin.close
-      stdout_str = stdout.gets
-      raise "Failed to generate WireGuard public key" unless wait_thr.value.success?
-    end
-
-    stdout_str.strip
+    [private_key, public_key]
   end
 end

--- a/app/models/wg_config.rb
+++ b/app/models/wg_config.rb
@@ -3,6 +3,33 @@ require 'open3'
 
 class WgConfig < ApplicationRecord
 
+  DEFAULT_SETTINGS = {
+    'wgServerEndpoint' => {
+      description: 'WireGuard server endpoint (in format <IP>:<port>)',
+      value: 'localhost:1234'
+    },
+    'wgServerPublicKey' => {
+      description: 'WireGuard server public key',
+      value: ''
+    },
+    'wgFirstClientAddress' => {
+      description: 'WireGuard first client address',
+      value: '10.129.0.2'
+    },
+    'wgLastClientAddress' => {
+      description: 'WireGuard last client address',
+      value: '10.129.255.254'
+    },
+    'wgNetmask' => {
+      description: 'WireGuard netmask for virtual network',
+      value: '255.255.0.0'
+    },
+    'wgAllowedIPs' => {
+      description: 'WireGuard AllowedIPs client configuration parameter',
+      value: '10.129.0.0/16, 192.168.128.0/24'
+    }
+  }.freeze
+
   belongs_to :user
 
   validates :name, presence: true
@@ -11,6 +38,15 @@ class WgConfig < ApplicationRecord
   validates :name, uniqueness: { scope: :user_id }
 
   before_validation :generate_keys!, on: :create, if: -> { privatekey.blank? }
+
+  def self.ensure_default_settings!
+    DEFAULT_SETTINGS.each do |key, attributes|
+      Setting.find_or_create_by!(key: key) do |setting|
+        setting.description = attributes[:description]
+        setting.value = attributes[:value]
+      end
+    end
+  end
 
   def generate_keys!
     self.privatekey = gen_privatekey

--- a/app/models/wg_config.rb
+++ b/app/models/wg_config.rb
@@ -1,0 +1,80 @@
+require 'ipaddr'
+require 'open3'
+
+class WgConfig < ApplicationRecord
+
+  belongs_to :user
+
+  validates :name, presence: true
+  validates :privatekey, presence: true
+  validates :publickey, presence: true
+  validates :name, uniqueness: { scope: :user_id }
+
+  before_validation :generate_keys!, on: :create, if: -> { privatekey.blank? }
+
+  def generate_keys!
+    self.privatekey = gen_privatekey
+    self.publickey = gen_publickey(self.privatekey)
+  end
+
+  def addresses(as_networks=true)
+    raise "Model is not saved" if self.id.nil?
+
+    first = IPAddr.new(Setting['wgFirstClientAddress'])
+    last = IPAddr.new(Setting['wgLastClientAddress'])
+
+    ip = IPAddr.new(first.to_i + self.id, first.family)
+
+    raise "Failed to assign IP: out of range" if ip.to_i > last.to_i
+
+    return ip.to_s unless as_networks
+
+    "#{ip}/#{IPAddr.new(Setting['wgNetmask']).to_i.to_s(2).count('1')}"
+  end
+
+  def to_s
+    lines = []
+    lines << "# WireGuard config #{name}"
+    lines << '[Interface]'
+    lines << "PrivateKey = #{privatekey}"
+    lines << "Address = #{self.addresses}"
+    lines << ''
+    lines << '[Peer]'
+    lines << "PublicKey = #{Setting['wgServerPublicKey']}"
+    lines << "Endpoint = #{Setting['wgServerEndpoint']}"
+    lines << "AllowedIPs = #{Setting['wgAllowedIPs']}"
+
+    lines.join("\n")
+  end
+
+  def as_peer
+    s = []
+    s << "# User #{self.user_id}, config '#{self.name}'"
+    s << "[Peer]"
+    s << "PublicKey = #{publickey}"
+    s << "AllowedIPs = #{addresses(false)}"
+
+    s.join("\n")
+  end
+
+  private
+
+  def gen_privatekey
+    key, status = Open3.capture2("wg", "genkey")
+    raise "Failed to generate WireGuard private key" unless status.success?
+
+    key.strip
+  end
+
+  def gen_publickey(private_key)
+    stdout_str = ''
+    Open3.popen2("wg", "pubkey") do |stdin, stdout, wait_thr|
+      stdin.print(private_key)
+      stdin.close
+      stdout_str = stdout.gets
+      raise "Failed to generate WireGuard public key" unless wait_thr.value.success?
+    end
+
+    stdout_str.strip
+  end
+end

--- a/app/views/hackers/_form.html.haml
+++ b/app/views/hackers/_form.html.haml
@@ -140,3 +140,25 @@
       .form-group
         = submit_tag('Добавить публичный SSH ключ', class: 'btn btn-primary')
 
+-# WireGuard
+%hr
+.row#wg-configs
+  .col-lg-6
+    - unless @user.wg_configs.empty?
+      %h3 Конфигурации WireGuard
+      - @user.wg_configs.each do |wg|
+        .row.small
+          .col-lg-4
+            %p
+              = wg.name
+          .col-lg-1
+            %p
+              = link_to 'Удалить', user_wg_config_path(@user, wg), method: :delete, data: { confirm: 'Вы уверены?' }
+
+.row
+  .col-lg-6
+    = form_for [@user, @new_wg_config] do |f|
+      .form-group
+        = f.text_field :name, class: 'form-control'
+      .form-group
+        = submit_tag('Создать конфигурацию WireGuard', class: 'btn btn-primary')

--- a/app/views/hackers/_form.html.haml
+++ b/app/views/hackers/_form.html.haml
@@ -161,4 +161,6 @@
       .form-group
         = f.text_field :name, class: 'form-control'
       .form-group
+        = f.text_field :publickey, class: 'form-control', placeholder: 'Публичный ключ WireGuard'
+      .form-group
         = submit_tag('Создать конфигурацию WireGuard', class: 'btn btn-primary')

--- a/app/views/hackers/show.html.haml
+++ b/app/views/hackers/show.html.haml
@@ -74,3 +74,14 @@
       %h4= t('users.public_ssh_keys') + ':'
       - @user.public_ssh_keys.each do |public_ssh_key|
         .ssh-public-key= public_ssh_key.body
+
+-if @user.wg_configs.any?
+  .row.additional_info
+    .col-md-8
+      %h4= t('users.wg_configs') + ':'
+      - @user.wg_configs.each do |wg|
+        .wg_config.row
+          .col-lg-3
+            = wg.name
+          .col-lg-2
+            = link_to 'Скачать', user_wg_export_path(@user, wg), method: :post

--- a/app/views/hackers/show.html.haml
+++ b/app/views/hackers/show.html.haml
@@ -83,5 +83,5 @@
         .wg_config.row
           .col-lg-3
             = wg.name
-          .col-lg-2
-            = link_to 'Скачать', user_wg_export_path(@user, wg), method: :post
+          .col-lg-7
+            %code= wg.publickey

--- a/bin/wg-keypair
+++ b/bin/wg-keypair
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+private_key="$(wg genkey)"
+public_key="$(printf '%s' "${private_key}" | wg pubkey)"
+
+printf '%s\n%s\n' "${private_key}" "${public_key}"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -308,6 +308,7 @@ ru:
     telegram_username: Telegram
     github_username: Github
     public_ssh_keys: Public SSH keys
+    wg_configs: Конфигурации WireGuard
     last_payment_ended_at: Оплачено по
     last_seen_in_hackerspace: Видели в ХС
     learner: Курсант

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,11 +10,16 @@ Rails.application.routes.draw do
   get 'bramnik/find_user', to: 'bramnik#find_user'
   get 'bramnik/members_statistics', to: 'bramnik#members_statistics'
 
+  get 'wg_configs/export_peers', to: 'wg_configs#export_peers'
+
   resources :projects
   resources :news
   resources :devices, only: [:index, :show]
   resources :users, path: 'hackers', controller: 'hackers', only: [:index, :show, :edit, :update] do
     resources :public_ssh_keys, only: [:create, :destroy]
+
+    resources :wg_configs, only: [:create, :destroy]
+    post 'wg_configs/:id/export', to: 'wg_configs#export', as: 'wg_export'
 
     member do
       post 'add_mac', to: 'hackers#add_mac'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,7 @@
 development:
   secret_key_base: 78e82799f21e243031708009d6bbbfc467c5e3f37d8df52118ee218ac6f339e4ec9f44a77c937eb26a3f5bb80c39ced8fb2636590dbd4ef77b806b56093aedbc
   bramnik_token: abcdef
+  wireguard_token: abcdef
 staging:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   bramnik_token: abcdef

--- a/db/migrate/20221222221907_create_wg_configs.rb
+++ b/db/migrate/20221222221907_create_wg_configs.rb
@@ -2,7 +2,6 @@ class CreateWgConfigs < ActiveRecord::Migration[7.0]
   def up
     create_table :wg_configs do |t|
       t.string :name, null: false
-      t.string :privatekey, null: false
       t.string :publickey, null: false
 
       t.belongs_to :user, foreign_key: true

--- a/db/migrate/20221222221907_create_wg_configs.rb
+++ b/db/migrate/20221222221907_create_wg_configs.rb
@@ -1,0 +1,50 @@
+class CreateWgConfigs < ActiveRecord::Migration[7.0]
+  def up
+    create_table :wg_configs do |t|
+      t.string :name, null: false
+      t.string :privatekey, null: false
+      t.string :publickey, null: false
+
+      t.belongs_to :user, foreign_key: true
+
+      t.timestamps
+    end
+
+    Setting.create(key: 'wgServerEndpoint',
+                   description: 'WireGuard server endpoint (in format <IP>:<port>)',
+                   value: 'localhost:1234')
+
+    Setting.create(key: 'wgServerPublicKey',
+                   description: 'WireGuard server public key',
+                   value: '')
+
+    Setting.create(key: 'wgFirstClientAddress',
+                   description: 'WireGuard first client address',
+                   value: '10.129.0.2')
+
+    Setting.create(key: 'wgLastClientAddress',
+                   description: 'WireGuard last client address',
+                   value: '10.129.255.254')
+
+    Setting.create(key: 'wgNetmask',
+                   description: 'WireGuard netmask for virtual network',
+                   value: '255.255.0.0')
+
+    Setting.create(key: 'wgAllowedIPs',
+                   description: 'WireGuard AllowedIPs client configuration parameter',
+                   value: '10.129.0.0/16, 192.168.128.0/24')
+
+    say 'Run `rails wg_configs:generate_defaults` after installing WireGuard tools to create per-user configs.'
+  end
+
+  def down
+    Setting.where(key: 'wgServerEndpoint').delete_all
+    Setting.where(key: 'wgServerPublicKey').delete_all
+    Setting.where(key: 'wgFirstClientAddress').delete_all
+    Setting.where(key: 'wgLastClientAddress').delete_all
+    Setting.where(key: 'wgNetmask').delete_all
+    Setting.where(key: 'wgAllowedIPs').delete_all
+
+    drop_table :wg_configs
+  end
+end

--- a/db/migrate/20221222221907_create_wg_configs.rb
+++ b/db/migrate/20221222221907_create_wg_configs.rb
@@ -10,41 +10,10 @@ class CreateWgConfigs < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    Setting.create(key: 'wgServerEndpoint',
-                   description: 'WireGuard server endpoint (in format <IP>:<port>)',
-                   value: 'localhost:1234')
-
-    Setting.create(key: 'wgServerPublicKey',
-                   description: 'WireGuard server public key',
-                   value: '')
-
-    Setting.create(key: 'wgFirstClientAddress',
-                   description: 'WireGuard first client address',
-                   value: '10.129.0.2')
-
-    Setting.create(key: 'wgLastClientAddress',
-                   description: 'WireGuard last client address',
-                   value: '10.129.255.254')
-
-    Setting.create(key: 'wgNetmask',
-                   description: 'WireGuard netmask for virtual network',
-                   value: '255.255.0.0')
-
-    Setting.create(key: 'wgAllowedIPs',
-                   description: 'WireGuard AllowedIPs client configuration parameter',
-                   value: '10.129.0.0/16, 192.168.128.0/24')
-
-    say 'Run `rails wg_configs:generate_defaults` after installing WireGuard tools to create per-user configs.'
+    say 'Run `rails wg_configs:ensure_settings wg_configs:generate_defaults` after installing WireGuard tools.'
   end
 
   def down
-    Setting.where(key: 'wgServerEndpoint').delete_all
-    Setting.where(key: 'wgServerPublicKey').delete_all
-    Setting.where(key: 'wgFirstClientAddress').delete_all
-    Setting.where(key: 'wgLastClientAddress').delete_all
-    Setting.where(key: 'wgNetmask').delete_all
-    Setting.where(key: 'wgAllowedIPs').delete_all
-
     drop_table :wg_configs
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -278,9 +278,20 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_03_100233) do
     t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
+  create_table "wg_configs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.string "privatekey", null: false
+    t.string "publickey", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_wg_configs_on_user_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "nfc_keys", "users"
   add_foreign_key "public_ssh_keys", "users"
   add_foreign_key "users", "tariffs"
+  add_foreign_key "wg_configs", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -281,7 +281,6 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_03_100233) do
   create_table "wg_configs", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.string "privatekey", null: false
     t.string "publickey", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,30 @@ unless Rails.env.production?
   Setting.create(key: 'bib_password', value: '', description: 'Password for Belinvestbank')
   Setting.create(key: 'bramnikBotName', value: 'BramnikBot', description: 'Name of the Bramnik Telegram bot')
 
+  Setting.create(key: 'wgServerEndpoint',
+                 description: 'WireGuard server endpoint (in format <IP>:<port>)',
+                 value: 'localhost:1234')
+
+  Setting.create(key: 'wgServerPublicKey',
+                 description: 'WireGuard server public key',
+                 value: '')
+
+  Setting.create(key: 'wgFirstClientAddress',
+                 description: 'WireGuard first client address',
+                 value: '10.129.0.2')
+
+  Setting.create(key: 'wgLastClientAddress',
+                 description: 'WireGuard last client address',
+                 value: '10.129.255.254')
+
+  Setting.create(key: 'wgNetmask',
+                 description: 'WireGuard netmask for virtual network',
+                 value: '255.255.0.0')
+
+  Setting.create(key: 'wgAllowedIPs',
+                 description: 'WireGuard AllowedIPs client configuration parameter',
+                 value: '10.129.0.0/16, 192.168.128.0/24')
+
   remote_tariff = Tariff.create(
     ref_name: 'remote',
     name: 'Remote',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,29 +12,7 @@ unless Rails.env.production?
   Setting.create(key: 'bib_password', value: '', description: 'Password for Belinvestbank')
   Setting.create(key: 'bramnikBotName', value: 'BramnikBot', description: 'Name of the Bramnik Telegram bot')
 
-  Setting.create(key: 'wgServerEndpoint',
-                 description: 'WireGuard server endpoint (in format <IP>:<port>)',
-                 value: 'localhost:1234')
-
-  Setting.create(key: 'wgServerPublicKey',
-                 description: 'WireGuard server public key',
-                 value: '')
-
-  Setting.create(key: 'wgFirstClientAddress',
-                 description: 'WireGuard first client address',
-                 value: '10.129.0.2')
-
-  Setting.create(key: 'wgLastClientAddress',
-                 description: 'WireGuard last client address',
-                 value: '10.129.255.254')
-
-  Setting.create(key: 'wgNetmask',
-                 description: 'WireGuard netmask for virtual network',
-                 value: '255.255.0.0')
-
-  Setting.create(key: 'wgAllowedIPs',
-                 description: 'WireGuard AllowedIPs client configuration parameter',
-                 value: '10.129.0.0/16, 192.168.128.0/24')
+  WgConfig.ensure_default_settings!
 
   remote_tariff = Tariff.create(
     ref_name: 'remote',
@@ -233,4 +211,3 @@ unless Rails.env.production?
   )
 
 end
-

--- a/lib/tasks/wg_configs.rake
+++ b/lib/tasks/wg_configs.rake
@@ -1,6 +1,11 @@
 namespace :wg_configs do
+  desc 'Create default WireGuard settings if they are missing'
+  task ensure_settings: :environment do
+    WgConfig.ensure_default_settings!
+  end
+
   desc 'Generate default WireGuard configs for users missing one'
-  task generate_defaults: :environment do
+  task generate_defaults: [:environment, :ensure_settings] do
     User.find_each do |user|
       next if user.wg_configs.exists?(name: 'default')
 

--- a/lib/tasks/wg_configs.rake
+++ b/lib/tasks/wg_configs.rake
@@ -6,10 +6,14 @@ namespace :wg_configs do
 
   desc 'Generate default WireGuard configs for users missing one'
   task generate_defaults: [:environment, :ensure_settings] do
+    output_dir = Rails.root.join(ENV.fetch('OUTPUT_DIR', 'tmp/wg_configs'))
+    FileUtils.mkdir_p(output_dir)
+
     User.find_each do |user|
       next if user.wg_configs.exists?(name: 'default')
 
-      user.wg_configs.create!(name: 'default')
+      wg_config = user.wg_configs.create!(name: 'default')
+      File.write(output_dir.join("wg-hackerspace-user-#{user.id}.conf"), wg_config.to_s)
     end
   end
 end

--- a/lib/tasks/wg_configs.rake
+++ b/lib/tasks/wg_configs.rake
@@ -1,0 +1,10 @@
+namespace :wg_configs do
+  desc 'Generate default WireGuard configs for users missing one'
+  task generate_defaults: :environment do
+    User.find_each do |user|
+      next if user.wg_configs.exists?(name: 'default')
+
+      user.wg_configs.create!(name: 'default')
+    end
+  end
+end

--- a/spec/models/wg_config_spec.rb
+++ b/spec/models/wg_config_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe WgConfig, type: :model do
+  let(:user) { create(:user) }
+
+  before do
+    allow(Setting).to receive(:[]).and_call_original
+    allow(Setting).to receive(:[]).with('wgFirstClientAddress').and_return('10.129.0.2')
+    allow(Setting).to receive(:[]).with('wgLastClientAddress').and_return('10.129.255.254')
+    allow(Setting).to receive(:[]).with('wgNetmask').and_return('255.255.0.0')
+    allow(Setting).to receive(:[]).with('wgServerPublicKey').and_return('server-public')
+    allow(Setting).to receive(:[]).with('wgServerEndpoint').and_return('vpn.example.org:51820')
+    allow(Setting).to receive(:[]).with('wgAllowedIPs').and_return('10.129.0.0/16')
+  end
+
+  it 'stores only the generated public key' do
+    allow(Open3).to receive(:capture2)
+      .with(Rails.root.join('bin/wg-keypair').to_s)
+      .and_return(["client-private\nclient-public\n", instance_double(Process::Status, success?: true)])
+
+    config = user.wg_configs.create!(name: 'phone')
+
+    expect(config.publickey).to eq('client-public')
+    expect(config.privatekey).to eq('client-private')
+    expect(config.attributes).not_to have_key('privatekey')
+  end
+
+  it 'renders a one-time client config with the generated private key' do
+    allow(Open3).to receive(:capture2)
+      .with(Rails.root.join('bin/wg-keypair').to_s)
+      .and_return(["client-private\nclient-public\n", instance_double(Process::Status, success?: true)])
+
+    config = user.wg_configs.create!(name: 'phone')
+
+    expect(config.to_s).to include('PrivateKey = client-private')
+    expect(config.to_s).to include('PublicKey = ')
+    expect(config.as_peer).to include('PublicKey = client-public')
+  end
+
+  it 'accepts externally generated public keys without calling WireGuard tools' do
+    allow(Open3).to receive(:capture2).and_call_original
+
+    config = user.wg_configs.create!(name: 'laptop', publickey: 'client-public')
+
+    expect(Open3).not_to have_received(:capture2)
+    expect(config.privatekey).to be_nil
+    expect { config.to_s }.to raise_error(RuntimeError, /private key is not stored/)
+  end
+end


### PR DESCRIPTION
Add generation of WireGuard configurations for every user. User can download config to import it into WG client. The VPN server can retrieve all peers configurations for active users.