### PR TITLE
TinyMCE: image tools plugin removed as not supported for TinyMCE 6+

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,6 +101,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.tinymce.install = :compile
 end
 
 DISPLAY_GOOGLE_ANALYTICS = true

--- a/config/tinymce.yml
+++ b/config/tinymce.yml
@@ -4,7 +4,7 @@ link_context_toolbar: true
 menubar: false
 
 plugins:
-  - image link imagetools media table code lists
+  - image link media table code lists
 
 language: ru
 


### PR DESCRIPTION
Простая спроба пафiксіць радактар выдаленнем плагіна imagetools