### PR TITLE
Fix for News model default.png image url

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -30,7 +30,7 @@ class News < ApplicationRecord
                         medium: '500x500#',
                         thumb: '200x200>'
                     },
-                    default_url: 'default.png'
+                    default_url: '/images/default.png'
 
   validates_attachment_content_type :photo, content_type: /\Aimage\/.*\Z/
   validates_attachment :photo


### PR DESCRIPTION
падобна што з-за таго, што  незнаходзіла ў ассетах пуць на карцінку трэба было падправіць урл. Так не валіцца і адпавядае урлу які аддае nginx.
https://hackerspace.by/images/default.png
