### PR TITLE
User: run update_bepaid_bill action only on create and if tariff chan…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,13 +150,15 @@ class User < ApplicationRecord
       .where('suspended_changed_at > ?', Time.now - 1.day)
   }
 
-  after_save :update_bepaid_bill, :set_as_suspended
+  after_save :set_as_suspended
   before_save :set_tariff_changed_at
   before_validation :normalize_tg_nickname
   after_initialize :set_default_tariff, if: :new_record?
   after_initialize :set_password, if: :new_record?
   validate :tariff_changes, on: :update
 
+  after_create :update_bepaid_bill
+  after_update :update_bepaid_bill, if: -> { tariff_id_previously_changed? || account_banned_previously_changed? }
   attr_accessor :updating_by
 
   # Return all users with fee expires after provided duration

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -233,4 +233,49 @@ describe User, type: :model  do
       end
     end
   end
+
+  describe '#update_bepaid_bill' do
+    let(:user) { create :user }
+    let(:tariff) { create :tariff }
+
+    it 'invokes update_bepaid_bill on create' do
+      new_user = build :user
+      expect(new_user).to receive(:update_bepaid_bill)
+      new_user.save
+    end
+
+    describe "on update" do
+      context 'when tariff was changed ' do
+        it 'invokes update_bepaid_bill' do
+          user.tariff_id = tariff.id
+
+          expect(user).to receive(:update_bepaid_bill)
+          user.save
+        end
+      end
+
+      context 'when tariff was not changed ' do
+        it 'not invokes update_bepaid_bill' do
+          expect(user).to_not receive(:update_bepaid_bill)
+          user.save
+        end
+      end
+
+      context 'when account_banned was changed ' do
+        it 'invokes update_bepaid_bill' do
+          user.account_banned = true
+
+          expect(user).to receive(:update_bepaid_bill)
+          user.save
+        end
+      end
+
+      context 'when account_banned was not changed ' do
+        it 'not invokes update_bepaid_bill' do
+          expect(user).to_not receive(:update_bepaid_bill)
+          user.save
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
…ged or account_banned changed.

Калі робіцца захаванне аб'екта user (напрыклад пад час лагіну), то ідзе HTTP запыт у Bepaid, які займае каля 700ms. 

Гэты фікс дадае логіку каб запыт ў Bepaid выконваўся толькі калі гэта патрэбна.

https://github.com/minsk-hackerspace/hackerspace.by/issues/697