### PR TITLE
bib.rb: Fix broken Belinvestbank login

### DIFF
--- a/lib/belinvestbank_api/bib.rb
+++ b/lib/belinvestbank_api/bib.rb
@@ -47,9 +47,12 @@ module BelinvestbankApi
 
       doc = Nokogiri::HTML(r.body)
 
-      keyLang = doc.css('script').find do |data|
-        Belinvestbankapi::Parse::keyLang(data)
-      end || ''
+      keyLang = ""
+      doc.css('script').each do |data|
+        if data.to_s =~ /keyLang":\[([^\]]+)/
+          keyLang = BelinvestbankApi::Parse::keyLang(data.to_s)
+        end
+      end
 
       begin
         r = query_login :post, '/signin', {login: @login_name, password: encode_password(@password, keyLang), typeSessionKey: 0}


### PR DESCRIPTION
Fix broken login to Belinvestbank website:
- fix typo in module name, 'Belinvestbankapi' instead of 'BelinvestbankApi' (introduced in the untested PR #682 9faf972 "Looks like module methods are not available in module classes");
- revert weird logic in '<script>' elements parsing, introduced in the 3fe4329 "Add input/output validation for BIB parser", PR #682;
- added data.to_s method to convert Nokogiri::XML::Element to string (error was introduced in the same commit).

Before reverting of 3fe4329, keyLang was returned as a full '<script>' element, not as value of keyLang attribute.