### PR TITLE
Fix Auto Devops test in GitLab

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,9 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
+    # Skip Safeguards for /test and test.sqlite paths in DATABASE_URL
+    DatabaseCleaner.url_allowlist = [ %r{/test(\.sqlite3?)?$} ]
+
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
Проблеме: если в тестах путь к БД не локальный - например, в контейнере postgres вместо localhost, то хелпер DatabaseCleaner отказывается работать и вылетает (см. https://github.com/minsk-hackerspace/hackerspace.by/issues/754).

Данный фикс заставляет Database спокойно чистить БД, если она называется `test`, `test.sqlite` или `test.sqlite3` вне зависимости от месторасположения. Тикет в апстиме https://github.com/DatabaseCleaner/database_cleaner/issues/727

---

* [x] DATABASE_URL value that is set by GitLab AutoDevops Auto Test
```
DEBUG: DATABASE_URL = postgres://user:testing-password@postgres:5432/test
```
* [x] DATABASE_URL value that is set by GitHub Actions
```
DEBUG: DATABASE_URL = sqlite3:db/test.sqlite3
```
* [x] Adjusted DatabaseCleaner config https://github.com/DatabaseCleaner/database_cleaner#safeguards

Fixes https://github.com/minsk-hackerspace/hackerspace.by/pull/754