### PR TITLE
fix: Let DATABASE_URL to be empty for DB cleaner

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,7 +73,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     # Skip Safeguards for /test and test.sqlite paths in DATABASE_URL
-    DatabaseCleaner.url_allowlist = [ %r{/test(\.sqlite3?)?$} ]
+    DatabaseCleaner.url_allowlist = [ %r{/test(\.sqlite3?)?$}, nil ]
 
     DatabaseCleaner.clean_with(:truncation)
   end


### PR DESCRIPTION
Fixes https://github.com/minsk-hackerspace/hackerspace.by/issues/762